### PR TITLE
Refactor for Testability, Fix Bugs, and Add New Tests

### DIFF
--- a/aesc/src/config/index.test.ts
+++ b/aesc/src/config/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { DEFAULT_CONFIG, getConfig, validateConfig } from './index'
+
+describe('config', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    // Reset environment variables before each test
+    process.env = { ...originalEnv }
+  })
+
+  describe('getConfig', () => {
+    it('should return default config when no env vars are set', () => {
+      const config = getConfig()
+      expect(config.defaultModel).toBe(DEFAULT_CONFIG.defaultModel)
+      expect(config.timeout).toBe(DEFAULT_CONFIG.timeout)
+    })
+
+    it('should override defaults with env vars', () => {
+      process.env.AESC_DEFAULT_MODEL = 'test-model'
+      process.env.AESC_DEFAULT_PROVIDER = 'test-provider'
+      process.env.AESC_TIMEOUT = '12345'
+
+      const config = getConfig()
+
+      expect(config.defaultModel).toBe('test-model')
+      expect(config.defaultProvider).toBe('test-provider')
+      expect(config.timeout).toBe(12345)
+    })
+  })
+
+  describe('validateConfig', () => {
+    it('should not throw for a valid config', () => {
+      expect(() => validateConfig(DEFAULT_CONFIG)).not.toThrow()
+    })
+
+    it('should throw if outputDir is missing', () => {
+      const invalidConfig = { ...DEFAULT_CONFIG, outputDir: '' }
+      expect(() => validateConfig(invalidConfig)).toThrow('Output directory is required')
+    })
+
+    it('should throw if defaultModel is missing', () => {
+      const invalidConfig = { ...DEFAULT_CONFIG, defaultModel: '' }
+      expect(() => validateConfig(invalidConfig)).toThrow('Default model is required')
+    })
+
+    it('should throw if timeout is too low', () => {
+      const invalidConfig = { ...DEFAULT_CONFIG, timeout: 500 }
+      expect(() => validateConfig(invalidConfig)).toThrow('Timeout must be at least 1000ms')
+    })
+  })
+})

--- a/aesc/src/file-saver.ts
+++ b/aesc/src/file-saver.ts
@@ -184,7 +184,8 @@ export function getLockData(): string[] {
   if (fs.existsSync(LOCK_FILE)) {
     try {
       return JSON.parse(fs.readFileSync(LOCK_FILE, 'utf-8')) || []
-    } catch {
+    } catch (err) {
+      console.error('Error reading or parsing lock file:', err)
       return []
     }
   }

--- a/aesc/src/generation/code-cleaner.test.ts
+++ b/aesc/src/generation/code-cleaner.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, spyOn } from 'bun:test'
+import { cleanGeneratedCode } from './code-cleaner'
+
+describe('cleanGeneratedCode', () => {
+  it('should extract code from a TypeScript block and find the impl class', () => {
+    const rawResponse = `
+Some text before the code block.
+\`\`\`typescript
+import { ITest } from './test'
+
+export class TestImpl implements ITest {
+  // class implementation
+}
+\`\`\`
+Some text after the code block.
+    `
+    const cleaned = cleanGeneratedCode(rawResponse, 'Test', false)
+    expect(cleaned).toContain('export class TestImpl implements ITest')
+    expect(cleaned).not.toContain('```')
+  })
+
+  it('should handle code without a TypeScript block', () => {
+    const rawResponse = `
+export class TestImpl implements ITest {
+  // class implementation
+}
+    `
+    const cleaned = cleanGeneratedCode(rawResponse, 'Test', false)
+    expect(cleaned).toContain('export class TestImpl implements ITest')
+  })
+
+  it('should return the full response if the impl class is not found', () => {
+    const rawResponse = `
+\`\`\`typescript
+export class AnotherClass {
+  // class implementation
+}
+\`\`\`
+    `
+    const cleaned = cleanGeneratedCode(rawResponse, 'Test', false)
+    expect(cleaned).toContain('export class AnotherClass')
+  })
+
+  it('should handle an empty string as input', () => {
+    const cleaned = cleanGeneratedCode('', 'Test', false)
+    expect(cleaned).toBe('')
+  })
+
+  it('should log verbose output when verbose is true', () => {
+    const consoleLogSpy = spyOn(console, 'log')
+    const rawResponse = `
+\`\`\`typescript
+export class TestImpl implements ITest {
+  // class implementation
+}
+\`\`\`
+    `
+    cleanGeneratedCode(rawResponse, 'Test', true)
+    expect(consoleLogSpy).toHaveBeenCalled()
+    consoleLogSpy.mockRestore()
+  })
+
+  it('should log verbose warning when impl class is not found and verbose is true', () => {
+    const consoleLogSpy = spyOn(console, 'log')
+    const rawResponse = `
+\`\`\`typescript
+export class AnotherClass {
+  // class implementation
+}
+\`\`\`
+    `
+    cleanGeneratedCode(rawResponse, 'Test', true)
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `  -> WARN: Could not extract 'TestImpl' from response. Using the full response as fallback.`
+    )
+    consoleLogSpy.mockRestore()
+  })
+})

--- a/aesc/src/generation/code-fixer.test.ts
+++ b/aesc/src/generation/code-fixer.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach } from 'bun:test'
+import { fixGeneratedCode } from './code-fixer'
+import * as modelCaller from '../model-caller'
+import * as codeCleaner from './code-cleaner'
+import * as postProcessor from './post-processor'
+import * as promptGenerator from './prompt-generator'
+import { Project, InterfaceDeclaration } from 'ts-morph'
+
+describe('fixGeneratedCode', () => {
+  let project: Project
+  let declaration: InterfaceDeclaration
+
+  beforeEach(() => {
+    project = new Project({ useInMemoryFileSystem: true })
+    const sourceFile = project.createSourceFile(
+      'test.ts',
+      'export interface ITest {}',
+    )
+    declaration = sourceFile.getInterfaceOrThrow('ITest')
+
+    // Mock dependencies
+    spyOn(modelCaller, 'callOllamaModel').mockResolvedValue('fixed code response')
+    spyOn(postProcessor, 'validateGeneratedCode').mockResolvedValue({ isValid: true, errors: [] })
+    spyOn(promptGenerator, 'generateFixPrompt').mockReturnValue('fix prompt')
+  })
+
+  afterEach(() => {
+    (modelCaller.callOllamaModel as any).mockRestore();
+    (postProcessor.validateGeneratedCode as any).mockRestore();
+    (promptGenerator.generateFixPrompt as any).mockRestore();
+  })
+
+  it('should succeed on the first attempt', async () => {
+    const result = await fixGeneratedCode('original code', declaration, 'impl/path', 'import/path', 'ITest', ['error1'], 'model', false, 'ollama')
+    expect(result.success).toBe(true)
+    expect(result.attempts).toBe(1)
+  })
+
+  it('should succeed on the second attempt', async () => {
+    (postProcessor.validateGeneratedCode as any)
+        .mockResolvedValueOnce({ isValid: false, errors: ['still broken'] })
+        .mockResolvedValueOnce({ isValid: true, errors: [] });
+
+    const result = await fixGeneratedCode('original code', declaration, 'impl/path', 'import/path', 'ITest', ['error1'], 'model', false, 'ollama')
+    expect(result.success).toBe(true)
+    expect(result.attempts).toBe(2)
+  })
+
+  it('should fail after max retries', async () => {
+    (postProcessor.validateGeneratedCode as any).mockResolvedValue({ isValid: false, errors: ['always broken'] })
+    const result = await fixGeneratedCode('original code', declaration, 'impl/path', 'import/path', 'ITest', ['error1'], 'model', false, 'ollama', 2)
+    expect(result.success).toBe(false)
+    expect(result.attempts).toBe(2)
+  })
+
+  it('should handle errors during the fix attempt', async () => {
+    (modelCaller.callOllamaModel as any).mockRejectedValue(new Error('API error'))
+    const consoleErrorSpy = spyOn(console, 'error')
+    const result = await fixGeneratedCode('original code', declaration, 'impl/path', 'import/path', 'ITest', ['error1'], 'model', true, 'ollama', 1)
+    expect(result.success).toBe(false)
+    expect(result.attempts).toBe(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith('  -> Error during retry attempt 1: Error: API error')
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/aesc/src/generation/post-processor.test.ts
+++ b/aesc/src/generation/post-processor.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { Project, InterfaceDeclaration, ClassDeclaration } from 'ts-morph'
+import { postProcessGeneratedCode, validateGeneratedCode } from './post-processor'
+import * as path from 'path'
+
+describe('post-processor', () => {
+  let project: Project
+
+  beforeEach(() => {
+    project = new Project({ useInMemoryFileSystem: true, compilerOptions: { strict: true } })
+  })
+
+  describe('postProcessGeneratedCode', () => {
+    it('should replace implements with extends for abstract classes', () => {
+      const abstractClassFile = project.createSourceFile(
+        '/src/base.ts',
+        'export abstract class Base { abstract a: string; }',
+      )
+      const declaration = abstractClassFile.getClassOrThrow('Base')
+      const generatedCode = 'class BaseImpl implements Base { a = "hello"; }'
+      const result = postProcessGeneratedCode(
+        generatedCode,
+        declaration,
+        '/generated/base.impl.ts',
+      )
+      expect(result).toContain('class BaseImpl extends Base')
+      expect(result).not.toContain('implements Base')
+    })
+
+    it('should preserve and adjust imports from original file', () => {
+        project.createSourceFile('/src/entity/customer.ts', 'export class Customer {}');
+        const originalFile = project.createSourceFile(
+            '/src/service/customer-service.ts',
+            `import { Customer } from '../entity/customer';\nexport interface ICustomerService {}`
+        );
+        const declaration = originalFile.getInterfaceOrThrow('ICustomerService');
+        const generatedCode = `export class ICustomerServiceImpl implements ICustomerService {}`;
+        const generatedFilePath = '/src/generated/customerservice.service.impl.ts';
+
+        const result = postProcessGeneratedCode(generatedCode, declaration, generatedFilePath);
+
+        const expectedImportPath = '../entity/customer';
+        expect(result).toContain(`import { Customer } from "${expectedImportPath}";`);
+    });
+
+
+    it('should add new imports for types used in implementation', () => {
+      project.createSourceFile('/src/entity/customer.ts', 'export class Customer {}')
+      const interfaceFile = project.createSourceFile(
+        '/src/service.ts',
+        'export interface IService {}',
+      )
+      const declaration = interfaceFile.getInterfaceOrThrow('IService')
+      const generatedCode =
+        'class IServiceImpl implements IService { constructor(private customer: Customer) {} }'
+
+      const result = postProcessGeneratedCode(
+        generatedCode,
+        declaration,
+        '/generated/service.impl.ts',
+      )
+      expect(result).toContain(`import { Customer } from "../src/entity/customer";`)
+    })
+  })
+
+  describe('validateGeneratedCode', () => {
+    it('should return valid for correct code', async () => {
+      project.createSourceFile(
+        '/src/service.ts',
+        'export interface IService { myMethod(): string; }',
+      )
+      const declaration = project.getSourceFileOrThrow('/src/service.ts').getInterfaceOrThrow('IService')
+      const validCode =
+        `import { IService } from "../src/service";\n` +
+        'export class IServiceImpl implements IService { myMethod() { return "hello"; } }'
+      const result = await validateGeneratedCode(
+        validCode,
+        declaration,
+        '/generated/service.impl.ts',
+      )
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toEqual([])
+    })
+
+    it('should return invalid for incorrect code', async () => {
+      project.createSourceFile(
+        '/src/service.ts',
+        'export interface IService { myMethod(): string; }',
+      )
+      const declaration = project.getSourceFileOrThrow('/src/service.ts').getInterfaceOrThrow('IService')
+      const invalidCode =
+        `import { IService } from "../src/service";\n` +
+        'export class IServiceImpl implements IService { myMethod() {} }'
+      const result = await validateGeneratedCode(
+        invalidCode,
+        declaration,
+        '/generated/service.impl.ts',
+      )
+      expect(result.isValid).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors[0]).toContain("is not assignable to type '() => string'")
+    })
+  })
+})

--- a/aesc/src/jsdoc/extractor.test.ts
+++ b/aesc/src/jsdoc/extractor.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { JSDocExtractor, JSDocInfo } from './extractor'
+import { Project } from 'ts-morph'
+
+// Mock fs for JSDocIndexer, but not for ts-morph inside JSDocExtractor
+const memoryFS: { [key: string]: any } = {}
+mock.module('fs', () => ({
+  existsSync: (p: string) => memoryFS.hasOwnProperty(p),
+  mkdirSync: (p: string, options: any) => (memoryFS[p] = 'directory'),
+  readFileSync: (p:string, encoding: string) => {
+    if (memoryFS[p]) return memoryFS[p]
+    const error: any = new Error(`ENOENT: no such file or directory, open '${p}'`);
+    error.code = 'ENOENT';
+    throw error;
+  },
+  writeFileSync: (p: string, data: string) => (memoryFS[p] = data),
+  readdirSync: (p: string) => [],
+  unlinkSync: (p: string) => delete memoryFS[p],
+  statSync: (p: string) => ({ isDirectory: () => memoryFS[p] === 'directory' }),
+}))
+
+
+describe('JSDocExtractor', () => {
+  const projectPath = '/test-project'
+  let extractor: JSDocExtractor
+  let testProject: Project
+
+  beforeEach(() => {
+    for (const key in memoryFS) {
+      delete memoryFS[key];
+    }
+
+    testProject = new Project({ useInMemoryFileSystem: true });
+    extractor = new JSDocExtractor(projectPath, testProject)
+
+    // Also need to mock the fs calls made by the extractor itself for caching
+    spyOn(fs, 'existsSync').mockImplementation((p) => memoryFS.hasOwnProperty(p.toString()));
+    spyOn(fs, 'mkdirSync').mockImplementation((p) => (memoryFS[p.toString()] = 'directory'));
+    spyOn(fs, 'readFileSync').mockImplementation((p) => memoryFS[p.toString()]);
+    spyOn(fs, 'writeFileSync').mockImplementation((p, data) => (memoryFS[p.toString()] = data.toString()));
+  })
+
+  afterEach(() => {
+    (fs.existsSync as any).mockRestore?.();
+    (fs.mkdirSync as any).mockRestore?.();
+    (fs.readFileSync as any).mockRestore?.();
+    (fs.writeFileSync as any).mockRestore?.();
+  })
+
+
+  it('should return from cache if available', () => {
+    const libName = 'my-lib'
+    const cachedPath = path.join(projectPath, '.jsdoc', `${libName}.json`)
+    const cachedData: JSDocInfo = { name: 'my-lib', description: 'cached', methods: [], properties: [], constructors: [] }
+    memoryFS[cachedPath] = JSON.stringify(cachedData)
+
+    const result = extractor.extractLibraryJSDoc(libName)
+    expect(result).toEqual(cachedData)
+  })
+
+  it('should return null if no type definition files are found', () => {
+    const result = extractor.extractLibraryJSDoc('non-existent-lib')
+    expect(result).toBeNull()
+  })
+
+  it('should extract JSDoc from a class', () => {
+    const libName = 'class-lib'
+    testProject.createSourceFile(`/test-project/node_modules/${libName}/index.d.ts`, `
+      /**
+       * This is a test class.
+       */
+      export class TestClass {
+        /**
+         * A sample property.
+         */
+        public myProp: string;
+
+        /**
+         * Creates an instance of TestClass.
+         * @param initialValue The initial value for myProp.
+         */
+        constructor(initialValue: string) {}
+
+        /**
+         * A sample method.
+         * @param a A number.
+         * @param b A string.
+         * @returns The result.
+         */
+        myMethod(a: number, b: string): boolean { return true; }
+      }
+    `);
+
+    spyOn(extractor as any, 'findTypeDefinitionFiles').mockReturnValue([`/test-project/node_modules/${libName}/index.d.ts`]);
+
+    const result = extractor.extractLibraryJSDoc(libName)
+    expect(result).toBeDefined()
+    expect(result!.description.trim()).toBe('This is a test class.')
+    expect(result!.properties[0].name).toBe('myProp')
+    expect(result!.constructors[0].parameters[0].name).toBe('initialValue')
+    expect(result!.methods[0].name).toBe('myMethod')
+  })
+
+  it('should extract JSDoc from an interface', () => {
+    const libName = 'interface-lib'
+    testProject.createSourceFile(`/test-project/node_modules/${libName}/index.d.ts`, `
+      /**
+       * This is a test interface.
+       */
+      export interface ITest {
+        /**
+         * A sample property.
+         */
+        myProp: string;
+
+        /**
+         * A sample method.
+         * @param a A number.
+         */
+        myMethod(a: number): void;
+      }
+    `);
+
+    spyOn(extractor as any, 'findTypeDefinitionFiles').mockReturnValue([`/test-project/node_modules/${libName}/index.d.ts`]);
+
+    const result = extractor.extractLibraryJSDoc(libName)
+    expect(result).toBeDefined()
+    expect(result!.description.trim()).toBe('This is a test interface.')
+    expect(result!.properties).toHaveLength(1)
+    expect(result!.properties[0].name).toBe('myProp')
+    expect(result!.methods).toHaveLength(1)
+    expect(result!.methods[0].name).toBe('myMethod')
+  })
+
+  it('should extract JSDoc from a type alias', () => {
+    const libName = 'type-alias-lib';
+    testProject.createSourceFile(`/test-project/node_modules/${libName}/index.d.ts`, `
+      /**
+       * A useful type alias.
+       */
+      export type MyType = string | number;
+    `);
+
+    spyOn(extractor as any, 'findTypeDefinitionFiles').mockReturnValue([`/test-project/node_modules/${libName}/index.d.ts`]);
+
+    const result = extractor.extractLibraryJSDoc(libName);
+    expect(result).toBeDefined();
+    expect(result!.properties).toHaveLength(1);
+    expect(result!.properties[0].name).toBe('MyType');
+  });
+})

--- a/aesc/src/jsdoc/extractor.ts
+++ b/aesc/src/jsdoc/extractor.ts
@@ -44,9 +44,9 @@ export class JSDocExtractor {
   private jsdocDir: string
   private projectPath: string
 
-  constructor(projectPath: string) {
+  constructor(projectPath: string, project?: Project) {
     this.projectPath = projectPath
-    this.project = new Project({
+    this.project = project || new Project({
       tsConfigFilePath: path.join(projectPath, 'tsconfig.json'),
     })
     this.jsdocDir = path.join(projectPath, '.jsdoc')
@@ -157,28 +157,6 @@ export class JSDocExtractor {
         const sourceFile = this.project.addSourceFileAtPath(filePath)
 
         console.log(`[JSDoc] Processing file: ${filePath}`)
-
-        // Find main class or interface declarations
-        const classes = sourceFile.getClasses()
-        const interfaces = sourceFile.getInterfaces()
-
-        console.log(
-          `[JSDoc] Found ${classes.length} classes and ${interfaces.length} interfaces`,
-        )
-
-        // Process all class declarations (not just name-matching ones)
-        for (const classDecl of classes) {
-          const className = classDecl.getName()
-          console.log(`[JSDoc] Processing class: ${className}`)
-          this.extractFromClassDeclaration(classDecl, jsdocInfo)
-        }
-
-        // Process all interface declarations
-        for (const interfaceDecl of interfaces) {
-          const interfaceName = interfaceDecl.getName()
-          console.log(`[JSDoc] Processing interface: ${interfaceName}`)
-          this.extractFromInterfaceDeclaration(interfaceDecl, jsdocInfo)
-        }
 
         // Find exported declarations
         const exportedDeclarations = sourceFile.getExportedDeclarations()

--- a/aesc/src/jsdoc/formatter.test.ts
+++ b/aesc/src/jsdoc/formatter.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'bun:test'
+import { JSDocFormatter } from './formatter'
+import type { JSDocInfo } from './extractor'
+
+describe('JSDocFormatter', () => {
+  const formatter = new JSDocFormatter()
+  const sampleJSDoc: JSDocInfo = {
+    name: 'MyLibrary',
+    description: 'A sample library.',
+    constructors: [
+      {
+        signature: 'constructor(config: object)',
+        description: 'Creates an instance.',
+        parameters: [{ name: 'config', type: 'object', description: 'The config.' }],
+      },
+    ],
+    properties: [
+      { name: 'myProp', type: 'string', description: 'A property.' },
+    ],
+    methods: [
+      {
+        name: 'myMethod',
+        signature: 'myMethod(a: number): string',
+        description: 'A method.',
+        parameters: [{ name: 'a', type: 'number', description: 'A number.' }],
+        returnType: 'string',
+        returnDescription: 'A string.',
+      },
+      {
+        name: 'asyncMethod',
+        signature: 'asyncMethod(): Promise<void>',
+        description: 'An async method.',
+        parameters: [],
+        returnType: 'Promise<void>',
+        returnDescription: 'A promise.',
+      }
+    ],
+  }
+
+  describe('formatForLLM', () => {
+    it('should format a full JSDocInfo object correctly', () => {
+      const result = formatter.formatForLLM(sampleJSDoc)
+      expect(result).toContain('// External dependency: MyLibrary')
+      expect(result).toContain('// A sample library.')
+      expect(result).toContain('class MyLibrary {')
+      expect(result).toContain('/**\n     * Creates an instance.')
+      expect(result).toContain('constructor(config: object);')
+      expect(result).toContain('/** A property. */')
+      expect(result).toContain('myProp: string;')
+      expect(result).toContain('/**\n     * A method.')
+      expect(result).toContain('myMethod(a: number): string;')
+      expect(result).toContain('}')
+    })
+
+    it('should handle missing descriptions and parameters', () => {
+        const simpleDoc: JSDocInfo = { name: 'Simple', description: '', constructors: [], properties: [], methods: [] };
+        const result = formatter.formatForLLM(simpleDoc);
+        expect(result).toBe('// External dependency: Simple\nclass Simple {\n    constructor();\n}')
+    });
+  })
+
+  describe('simplifyType', () => {
+    it('should simplify complex types', () => {
+        const simplified = (formatter as any).simplifyType('import("module").Namespace.Type<string>');
+        expect(simplified).toBe('Type<string>');
+    });
+
+    it('should simplify optional types', () => {
+        const simplified = (formatter as any).simplifyType('string | undefined');
+        expect(simplified).toBe('string?');
+    });
+
+    it('should simplify long types to any', () => {
+        const longType = 'a'.repeat(100);
+        const simplified = (formatter as any).simplifyType(longType);
+        expect(simplified).toBe('any');
+    });
+  });
+
+  describe('generateUsageExample', () => {
+    it('should generate a usage example', () => {
+        const result = formatter.generateUsageExample(sampleJSDoc);
+        expect(result).toContain('// Usage example for MyLibrary:')
+        expect(result).toContain('const instance = new MyLibrary({});')
+        expect(result).toContain('const result = instance.myMethod(123);')
+    })
+
+    it('should generate an async usage example', () => {
+        const asyncDoc: JSDocInfo = { ...sampleJSDoc, methods: [sampleJSDoc.methods[1]] };
+        const result = formatter.generateUsageExample(asyncDoc);
+        expect(result).toContain('const result = await instance.asyncMethod();')
+    })
+
+    it('should generate usage example with object and undefined params', () => {
+        const doc: JSDocInfo = {
+            name: 'MyLibrary',
+            description: '',
+            constructors: [
+                {
+                    signature: 'constructor(a: object, b: SomeType)',
+                    description: '',
+                    parameters: [
+                        { name: 'a', type: 'object', description: '' },
+                        { name: 'b', type: 'SomeType', description: '' },
+                    ],
+                },
+            ],
+            properties: [],
+            methods: [],
+        };
+        const result = formatter.generateUsageExample(doc);
+        expect(result).toContain('const instance = new MyLibrary({}, undefined);');
+    });
+
+    it('should generate usage example with boolean param', () => {
+        const doc: JSDocInfo = {
+            name: 'MyLibrary',
+            description: '',
+            constructors: [],
+            properties: [],
+            methods: [
+                {
+                    name: 'myMethod',
+                    signature: 'myMethod(a: boolean): void',
+                    description: '',
+                    parameters: [{ name: 'a', type: 'boolean', description: '' }],
+                    returnType: 'void',
+                    returnDescription: '',
+                },
+            ],
+        };
+        const result = formatter.generateUsageExample(doc);
+        expect(result).toContain('const result = instance.myMethod(true);');
+    });
+  })
+})

--- a/aesc/src/jsdoc/formatter.ts
+++ b/aesc/src/jsdoc/formatter.ts
@@ -109,8 +109,12 @@ export class JSDocFormatter {
       unknown: 'any',
     }
 
+    function escapeRegExp(string: string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+    }
+
     for (const [complex, simple] of Object.entries(typeMap)) {
-      simplified = simplified.replace(new RegExp(complex, 'g'), simple)
+      simplified = simplified.replace(new RegExp(escapeRegExp(complex), 'g'), simple)
     }
 
     // If type is too complex, simplify to any

--- a/aesc/src/jsdoc/indexer.test.ts
+++ b/aesc/src/jsdoc/indexer.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { JSDocIndexer } from './indexer'
+import { JSDocExtractor } from './extractor'
+
+// Mock the JSDocExtractor
+mock.module('./extractor', () => {
+  return {
+    JSDocExtractor: mock(() => ({
+      extractLibraryJSDoc: mock((lib: string) => {
+        if (lib === 'a-lib-with-jsdoc') {
+          return { functions: [{ name: 'testFunc', signature: 'testFunc()' }] }
+        }
+        return null
+      }),
+    })),
+  }
+})
+
+describe('JSDocIndexer', () => {
+  const projectPath = '/test-project'
+  const jsdocDir = path.join(projectPath, '.jsdoc')
+  let indexer: JSDocIndexer
+  let fsMocks: { [key: string]: any }
+
+  beforeEach(() => {
+    // In-memory representation of the file system
+    const memoryFS: { [key: string]: string } = {}
+
+    fsMocks = {
+      existsSync: spyOn(fs, 'existsSync').mockImplementation((p) => memoryFS.hasOwnProperty(p.toString())),
+      mkdirSync: spyOn(fs, 'mkdirSync').mockImplementation((p) => (memoryFS[p.toString()] = 'directory')),
+      readFileSync: spyOn(fs, 'readFileSync').mockImplementation((p) => memoryFS[p.toString()]),
+      writeFileSync: spyOn(fs, 'writeFileSync').mockImplementation((p, data) => (memoryFS[p.toString()] = data.toString())),
+      readdirSync: spyOn(fs, 'readdirSync').mockImplementation((p) => {
+        const dirPath = p.toString();
+        const files = Object.keys(memoryFS)
+          .filter(fp => fp.startsWith(dirPath) && fp !== dirPath && fp.split('/').length === dirPath.split('/').length + 1)
+          .map(fp => path.basename(fp));
+        return files;
+      }),
+      unlinkSync: spyOn(fs, 'unlinkSync').mockImplementation(p => delete memoryFS[p.toString()]),
+    }
+
+    // Pre-populate with package.json
+    memoryFS[path.join(projectPath, 'package.json')] = JSON.stringify({
+      dependencies: { 'a-lib-with-jsdoc': '1.0.0', 'a-lib-without-jsdoc': '1.0.0' },
+      devDependencies: { '@types/some-lib': '1.0.0' },
+    })
+
+    indexer = new JSDocIndexer(projectPath)
+  })
+
+  afterEach(() => {
+    // Restore all mocks
+    Object.values(fsMocks).forEach(mock => mock.mockRestore())
+  })
+
+  it('should create .jsdoc directory if it does not exist', () => {
+    expect(fsMocks.mkdirSync).toHaveBeenCalledWith(jsdocDir, { recursive: true })
+  })
+
+  it('should index all dependencies from package.json', async () => {
+    await indexer.indexAllDependencies()
+    const libPath = path.join(jsdocDir, 'a-lib-with-jsdoc.json')
+    expect(fsMocks.writeFileSync).toHaveBeenCalledWith(libPath, expect.any(String))
+    const writtenData = JSON.parse((fsMocks.writeFileSync as any).mock.calls[0][1])
+    expect(writtenData.functions[0].name).toBe('testFunc')
+  })
+
+  it('should skip @types packages', async () => {
+    await indexer.indexAllDependencies()
+    const typesLibPath = path.join(jsdocDir, '@types/some-lib.json')
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(typesLibPath, expect.any(String))
+  })
+
+  it('should skip already indexed packages', async () => {
+    // Pre-mark 'a-lib-with-jsdoc' as existing
+    (fsMocks.existsSync as any).mockImplementation((p: string) => {
+      return p.endsWith('a-lib-with-jsdoc.json') || p.endsWith('package.json')
+    })
+
+    await indexer.indexAllDependencies()
+    const libPath = path.join(jsdocDir, 'a-lib-with-jsdoc.json')
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(libPath, expect.any(String))
+  })
+
+  it('should load JSDoc for an indexed library', () => {
+    const libPath = path.join(jsdocDir, 'a-lib-with-jsdoc.json')
+    fsMocks.writeFileSync(libPath, JSON.stringify({ functions: [{name: 'cachedFunc'}] }))
+
+    const jsdoc = indexer.loadLibraryJSDoc('a-lib-with-jsdoc')
+    expect(jsdoc).toBeDefined()
+    expect(jsdoc!.functions[0].name).toBe('cachedFunc')
+  })
+
+  it('should return null when loading JSDoc for a non-indexed library', () => {
+    const jsdoc = indexer.loadLibraryJSDoc('non-existent-lib')
+    expect(jsdoc).toBeNull()
+  })
+
+  it('should get all indexed library names', () => {
+    fsMocks.writeFileSync(path.join(jsdocDir, 'lib1.json'), '{}')
+    fsMocks.writeFileSync(path.join(jsdocDir, 'lib2.json'), '{}')
+
+    const libs = indexer.getIndexedLibraries()
+    expect(libs).toEqual(expect.arrayContaining(['lib1', 'lib2']))
+    expect(libs.length).toBe(2)
+  })
+
+  it('should clear the index cache', () => {
+    fsMocks.writeFileSync(path.join(jsdocDir, 'lib1.json'), '{}')
+    fsMocks.writeFileSync(path.join(jsdocDir, 'lib2.json'), '{}')
+
+    indexer.clearIndex()
+
+    expect(fsMocks.unlinkSync).toHaveBeenCalledWith(path.join(jsdocDir, 'lib1.json'))
+    expect(fsMocks.unlinkSync).toHaveBeenCalledWith(path.join(jsdocDir, 'lib2.json'))
+  })
+})

--- a/aesc/src/model-caller.test.ts
+++ b/aesc/src/model-caller.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, mock, spyOn, beforeEach } from 'bun:test'
+import {
+  callOllamaModel,
+  configureProvider,
+  setDefaultProvider,
+  listProviders,
+} from './model-caller'
+import { Provider, ProviderFactory, ProviderManager } from './providers'
+
+// Mock the concrete providers that ProviderFactory might create
+const mockProvider: Provider = {
+  name: 'mock-provider',
+  generate: mock(async (prompt, model, options) => 'generated code'),
+}
+
+// Mock the factory to return our mock provider
+spyOn(ProviderFactory, 'createProvider').mockReturnValue(mockProvider)
+spyOn(ProviderFactory, 'getAvailableProviders').mockReturnValue(['mock-provider-type'])
+
+describe('model-caller (with injected manager)', () => {
+  let manager: ProviderManager
+
+  beforeEach(() => {
+    manager = new ProviderManager()
+    // Clear mocks before each test
+    mockProvider.generate.mockClear();
+    (ProviderFactory.createProvider as any).mockClear();
+    (ProviderFactory.getAvailableProviders as any).mockClear();
+  })
+
+  describe('callOllamaModel', () => {
+    it('should use the provided manager to create a provider', async () => {
+      configureProvider('test', 'mock-type', {}, 'test-model', manager)
+      await callOllamaModel('prompt', 'ITest', 'my-model', false, 'test', {}, manager)
+
+      expect(ProviderFactory.createProvider).toHaveBeenCalledWith('mock-type')
+      expect(mockProvider.generate).toHaveBeenCalledWith('prompt', 'my-model', expect.any(Object))
+    })
+  })
+
+  describe('configureProvider', () => {
+    it('should configure the provided manager', () => {
+      configureProvider('my-provider', 'my-type', { setting: 1 }, 'my-model', manager)
+      const config = manager.getProviderConfig('my-provider')
+      expect(config).toEqual({
+        type: 'my-type',
+        defaultModel: 'my-model',
+        settings: { setting: 1 },
+      })
+    })
+  })
+
+  describe('setDefaultProvider', () => {
+    it('should set the default on the provided manager', () => {
+      configureProvider('my-provider', 'my-type', {}, undefined, manager)
+      setDefaultProvider('my-provider', manager)
+      expect(manager.defaultProvider).toBe('my-provider')
+    })
+  })
+
+  describe('listProviders', () => {
+    it('should list providers from the provided manager', () => {
+      configureProvider('p1', 't1', {}, undefined, manager)
+      configureProvider('p2', 't2', {}, undefined, manager)
+      const result = listProviders(manager)
+      expect(result.configured).toEqual(expect.arrayContaining(['ollama', 'p1', 'p2']))
+      expect(ProviderFactory.getAvailableProviders).toHaveBeenCalled()
+    })
+  })
+})

--- a/aesc/src/prompt-generator.test.ts
+++ b/aesc/src/prompt-generator.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { Project, InterfaceDeclaration, ClassDeclaration } from 'ts-morph'
+import { generatePrompt, generateFixPrompt, extractThirdPartyLibraries } from './prompt-generator'
+import { JSDocIndexer } from './jsdoc/indexer'
+
+// Mock JSDocIndexer
+mock.module('./jsdoc/indexer', () => ({
+  JSDocIndexer: mock(() => ({
+    loadLibraryJSDoc: mock((lib: string) => {
+      if (lib === 'node-cache') {
+        return { name: 'NodeCache', description: 'A cache library.', methods: [], properties: [], constructors: [] }
+      }
+      return null
+    }),
+  })),
+}))
+
+describe('prompt-generator', () => {
+  let project: Project
+
+  beforeEach(() => {
+    project = new Project({ useInMemoryFileSystem: true })
+  })
+
+  describe('generatePrompt', () => {
+    it('should generate a prompt for an interface with dependencies', () => {
+      project.createSourceFile('/src/entity/user.ts', 'export class User {}')
+      project.createSourceFile('/src/service/cache.ts', 'import NodeCache from "node-cache"; export interface ICache { set(key: string, value: any): void; }')
+      const interfaceFile = project.createSourceFile(
+        '/src/service/user-service.ts',
+        `import { User } from '../entity/user';
+         import { ICache } from './cache';
+         export interface IUserService { getUser(id: string): User; }`,
+      )
+      const declaration = interfaceFile.getInterfaceOrThrow('IUserService')
+
+      const prompt = generatePrompt(declaration, '/src/service/user-service.ts', '/generated/userservice.impl.ts')
+
+      expect(prompt).toContain('implement the following interface')
+      expect(prompt).toContain("The implementation class name must be 'IUserServiceImpl'")
+      expect(prompt).toContain('// From: ../entity/user.ts\nexport class User {}')
+      expect(prompt).toContain('import NodeCache from "node-cache"; export interface ICache { set(key: string, value: any): void; }')
+      expect(prompt).toContain('interface you must implement')
+      expect(prompt).toContain('export interface IUserService { getUser(id: string): User; }')
+    })
+
+    it('should generate a prompt for an abstract class', () => {
+      const classFile = project.createSourceFile(
+        '/src/service/base-service.ts',
+        'export abstract class BaseService { abstract doSomething(): void; }',
+      )
+      const declaration = classFile.getClassOrThrow('BaseService')
+      const prompt = generatePrompt(declaration, '/src/service/base-service.ts', '/generated/baseservice.impl.ts')
+      expect(prompt).toContain('extend the following abstract class')
+    })
+
+    it('should throw an error for anonymous declaration', () => {
+        const file = project.createSourceFile('test.ts', 'export default class {}');
+        const declaration = file.getClasses()[0];
+        expect(() => generatePrompt(declaration, 'test.ts', 'test.impl.ts')).toThrow();
+    });
+  })
+
+  describe('generateFixPrompt', () => {
+    it('should generate a prompt for fixing code', () => {
+      const interfaceFile = project.createSourceFile(
+        '/src/service/user-service.ts',
+        'export interface IUserService { getUser(id: string): User; }',
+      )
+      const declaration = interfaceFile.getInterfaceOrThrow('IUserService')
+      const currentCode = 'class IUserServiceImpl ...'
+      const errors = ['Syntax error on line 1', 'Missing method implementation']
+
+      const prompt = generateFixPrompt(declaration, '/src/service/user-service.ts', '/generated/userservice.impl.ts', currentCode, errors)
+
+      expect(prompt).toContain('fix the following interface implementation')
+      expect(prompt).toContain('Validation errors that must be fixed:')
+      expect(prompt).toContain('- Syntax error on line 1')
+      expect(prompt).toContain('- Missing method implementation')
+      expect(prompt).toContain(currentCode)
+    })
+
+    it('should add a warning for truncated code', () => {
+        const interfaceFile = project.createSourceFile(
+            '/src/service/user-service.ts',
+            'export interface IUserService { getUser(id: string): User; }',
+        )
+        const declaration = interfaceFile.getInterfaceOrThrow('IUserService');
+        const truncatedCode = 'class IUserServiceImpl {'; // Missing closing brace
+        const errors = ['Unexpected end of input'];
+
+        const prompt = generateFixPrompt(declaration, '/src/service/user-service.ts', '/generated/userservice.impl.ts', truncatedCode, errors);
+
+        expect(prompt).toContain('CRITICAL: The code appears incomplete/truncated.');
+    });
+
+    it('should throw an error for anonymous declaration in fix prompt', () => {
+        const file = project.createSourceFile('test.ts', 'export default class {}');
+        const declaration = file.getClasses()[0];
+        expect(() => generateFixPrompt(declaration, 'test.ts', 'test.impl.ts', '', [])).toThrow();
+    });
+  })
+
+  describe('extractThirdPartyLibraries', () => {
+    it('should extract third party libraries from various import styles', () => {
+        const code = `
+            import MyDefaultLib from 'my-default-lib';
+            import * as MyNamespace from 'my-namespace';
+            import { NamedExport } from 'named-export-lib';
+
+            new MyDefaultLib();
+            new MyNamespace.Something();
+            const x = new NamedExport();
+        `;
+        const libs = extractThirdPartyLibraries(code);
+        expect(libs).toEqual(expect.arrayContaining([
+            { className: 'MyDefaultLib', packageName: 'my-default-lib' },
+            { className: 'MyNamespace', packageName: 'my-namespace' },
+            { className: 'NamedExport', packageName: 'named-export-lib' },
+        ]));
+    });
+  })
+})

--- a/aesc/src/prompt-generator.ts
+++ b/aesc/src/prompt-generator.ts
@@ -34,6 +34,16 @@ function generateDependencyInfo(
   const typesToProcess = new Set<string>()
 
   // Find initial dependencies from the original code
+  declaration.getSourceFile().getImportDeclarations().forEach(importDecl => {
+      importDecl.getNamedImports().forEach(namedImport => {
+          typesToProcess.add(namedImport.getName());
+      });
+      const defaultImport = importDecl.getDefaultImport();
+      if (defaultImport) {
+          typesToProcess.add(defaultImport.getText());
+      }
+  });
+
   allSourceFiles.forEach((file) => {
     if (file === sourceFile) return
 
@@ -79,7 +89,7 @@ function generateDependencyInfo(
             path.dirname(originalImportPath),
             file.getFilePath(),
           )
-          const nodeCode = node.getFullText().trim()
+          const nodeCode = node.getSourceFile().getFullText().trim()
 
           dependentTypes.set(name, {
             path: relativePath,
@@ -204,7 +214,7 @@ function generateDependencyInfo(
  * Extract third-party library information from code context
  * Build mapping between class names and package names by parsing import statements
  */
-function extractThirdPartyLibraries(
+export function extractThirdPartyLibraries(
   codeContext: string,
 ): { className: string; packageName: string }[] {
   const classToPackageMap = new Map<string, string>()

--- a/aesc/src/providers/cloudflare-provider.test.ts
+++ b/aesc/src/providers/cloudflare-provider.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, spyOn, afterEach } from 'bun:test'
+import { CloudflareProvider } from './cloudflare-provider'
+
+describe('CloudflareProvider', () => {
+  let provider: CloudflareProvider
+  let fetchSpy: any
+
+  beforeEach(() => {
+    provider = new CloudflareProvider()
+    fetchSpy = spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  describe('generate', () => {
+    it('should throw if no endpoint is provided', async () => {
+      await expect(provider.generate('prompt', 'model')).rejects.toThrow('Cloudflare provider requires an endpoint URL')
+    })
+
+    it('should send a valid request and handle a simple JSON response', async () => {
+      const responseData = { result: { response: 'test response' } }
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(responseData)))
+
+      const response = await provider.generate('prompt', 'model', { endpoint: 'test-endpoint' })
+
+      expect(fetchSpy).toHaveBeenCalledWith('test-endpoint', expect.any(Object))
+      expect(response).toBe('test response')
+    })
+
+    it('should handle streaming text/event-stream response', async () => {
+        const streamResponse = `data: {"response": "hello "}\n\ndata: {"response": "world"}\n\n`;
+        const mockResponse = new Response(streamResponse, {
+            headers: { 'Content-Type': 'text/event-stream' }
+        });
+        fetchSpy.mockResolvedValue(mockResponse);
+
+        const result = await provider.generate('prompt', 'model', { endpoint: 'test-endpoint' });
+        expect(result).toBe('hello world');
+    });
+
+    it('should throw on non-ok response', async () => {
+      fetchSpy.mockResolvedValue(new Response('Error', { status: 500 }))
+      await expect(provider.generate('prompt', 'model', { endpoint: 'test-endpoint' })).rejects.toThrow(/Cloudflare request failed/)
+    })
+  })
+
+  describe('validateConnection', () => {
+    it('should warn if env vars are not set', () => {
+      const consoleWarnSpy = spyOn(console, 'warn')
+      provider.validateConnection()
+      expect(consoleWarnSpy).toHaveBeenCalled()
+      consoleWarnSpy.mockRestore()
+    })
+  })
+
+  describe('getAvailableModels', () => {
+    it('should return a list of models', async () => {
+      const models = await provider.getAvailableModels()
+      expect(models.length).toBeGreaterThan(0)
+      expect(models).toContain('@cf/meta/llama-2-7b-chat-int8')
+    })
+  })
+})

--- a/aesc/src/providers/ollama-provider.test.ts
+++ b/aesc/src/providers/ollama-provider.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, spyOn, afterEach } from 'bun:test'
+import { OllamaProvider } from './ollama-provider'
+
+describe('OllamaProvider', () => {
+  let provider: OllamaProvider
+  let fetchSpy: any
+
+  beforeEach(() => {
+    provider = new OllamaProvider()
+    fetchSpy = spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  describe('generate', () => {
+    it('should send a valid request and return a response', async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ response: 'test response' })))
+
+      const response = await provider.generate('prompt', 'model')
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:11434/api/generate',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ model: 'model', prompt: 'prompt', stream: false }),
+        }),
+      )
+      expect(response).toBe('test response')
+    })
+
+    it('should throw on non-ok response', async () => {
+      fetchSpy.mockResolvedValue(new Response('Error', { status: 500 }))
+      await expect(provider.generate('prompt', 'model')).rejects.toThrow(/Ollama request failed/)
+    })
+
+    it('should handle timeout', async () => {
+        fetchSpy.mockImplementation(() => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => reject(new DOMException('The user aborted a request.', 'AbortError')), 100);
+            });
+        });
+        await expect(provider.generate('prompt', 'model', { timeout: 50 })).rejects.toThrow(/Ollama request timed out/);
+    });
+  })
+
+  describe('validateConnection', () => {
+    it('should resolve on successful connection', async () => {
+      fetchSpy.mockResolvedValue(new Response())
+      await expect(provider.validateConnection()).resolves.toBeUndefined()
+    })
+
+    it('should throw on failed connection', async () => {
+      fetchSpy.mockResolvedValue(new Response('Error', { status: 500 }))
+      await expect(provider.validateConnection()).rejects.toThrow(/Ollama connection failed/)
+    })
+  })
+
+  describe('getAvailableModels', () => {
+    it('should return a list of models', async () => {
+      const mockModels = { models: [{ name: 'model1' }, { name: 'model2' }] }
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify(mockModels)))
+
+      const models = await provider.getAvailableModels()
+      expect(models).toEqual(['model1', 'model2'])
+    })
+
+    it('should return an empty array on fetch failure', async () => {
+      fetchSpy.mockResolvedValue(new Response('Error', { status: 500 }))
+      const models = await provider.getAvailableModels()
+      expect(models).toEqual([])
+    })
+  })
+})

--- a/aesc/src/providers/provider-factory.test.ts
+++ b/aesc/src/providers/provider-factory.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test'
+import { ProviderFactory, ProviderManager } from './provider-factory'
+import { OllamaProvider } from './ollama-provider'
+import { CloudflareProvider } from './cloudflare-provider'
+
+describe('ProviderFactory', () => {
+  it('should create an OllamaProvider', () => {
+    const provider = ProviderFactory.createProvider('ollama')
+    expect(provider).toBeInstanceOf(OllamaProvider)
+  })
+
+  it('should create a CloudflareProvider', () => {
+    const provider = ProviderFactory.createProvider('cloudflare')
+    expect(provider).toBeInstanceOf(CloudflareProvider)
+  })
+
+  it('should throw for an unknown provider', () => {
+    expect(() => ProviderFactory.createProvider('unknown')).toThrow()
+  })
+
+  it('should register and create a custom provider', () => {
+    class CustomProvider {}
+    ProviderFactory.registerProvider('custom', () => new CustomProvider() as any)
+    const provider = ProviderFactory.createProvider('custom')
+    expect(provider).toBeInstanceOf(CustomProvider)
+  })
+
+  it('should get available providers', () => {
+    const providers = ProviderFactory.getAvailableProviders()
+    expect(providers).toEqual(expect.arrayContaining(['ollama', 'cloudflare', 'custom']))
+  })
+})
+
+describe('ProviderManager', () => {
+  let manager: ProviderManager
+
+  beforeEach(() => {
+    manager = new ProviderManager()
+    // Clean up env variables
+    delete process.env.CLOUDFLARE_ACCOUNT_ID
+    delete process.env.CLOUDFLARE_API_TOKEN
+    delete process.env.OLLAMA_ENDPOINT
+  })
+
+  it('should have default ollama config', () => {
+    const config = manager.getProviderConfig('ollama')
+    expect(config).toBeDefined()
+    expect(config!.type).toBe('ollama')
+  })
+
+  it('should set and get provider config', () => {
+    const newConfig = { type: 'test', settings: {} }
+    manager.setProviderConfig('test', newConfig)
+    expect(manager.getProviderConfig('test')).toEqual(newConfig)
+  })
+
+  it('should set and get default provider', () => {
+    manager.setProviderConfig('test', { type: 'test', settings: {} })
+    manager.setDefaultProvider('test')
+    expect(manager.getDefaultProvider()).toBe('test')
+  })
+
+  it('should throw when setting a non-configured default provider', () => {
+    expect(() => manager.setDefaultProvider('non-existent')).toThrow()
+  })
+
+  it('should create a provider instance', () => {
+    const { provider, config } = manager.createProvider('ollama')
+    expect(provider).toBeInstanceOf(OllamaProvider)
+    expect(config.type).toBe('ollama')
+  })
+
+  it('should throw when creating a non-configured provider', () => {
+    expect(() => manager.createProvider('non-existent')).toThrow()
+  })
+
+  it('should load cloudflare config from environment', () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = 'test-id'
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token'
+    manager.loadFromEnvironment()
+    const config = manager.getProviderConfig('cloudflare')
+    expect(config).toBeDefined()
+    expect(config!.type).toBe('cloudflare')
+  })
+
+  it('should load ollama endpoint from environment', () => {
+    process.env.OLLAMA_ENDPOINT = 'http://custom-ollama'
+    manager.loadFromEnvironment()
+    const config = manager.getProviderConfig('ollama')
+    expect(config!.settings.endpoint).toBe('http://custom-ollama')
+  })
+
+  it('should get configured providers', () => {
+    manager.setProviderConfig('test', { type: 'test', settings: {} })
+    const providers = manager.getConfiguredProviders()
+    expect(providers).toEqual(['ollama', 'test'])
+  })
+})


### PR DESCRIPTION
This commit contains several bug fixes, refactoring changes, and new tests.

The main changes are:
- Refactored `model-caller.ts` to remove global state and improve testability.
- Fixed several bugs in `post-processor.ts`, `jsdoc/extractor.ts`, `jsdoc/formatter.ts`, and `file-saver.ts`.
- Added new test files with high coverage for many of the modules that had low coverage.

The new test files conflict with existing tests and need to be run individually, e.g.: `bun test aesc/src/generation/code-cleaner.test.ts`