### PR TITLE
Refactor: Clean up and fix noisy tests

### DIFF
--- a/aesc/tests/core/generator.test.ts
+++ b/aesc/tests/core/generator.test.ts
@@ -182,6 +182,8 @@ describe('generator', () => {
 
     it('should handle generation errors gracefully', async () => {
       // Arrange
+      const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+      spies.push(consoleErrorSpy)
       const sourceFile = project.createSourceFile(
         'src/services/user-service.ts',
         'export abstract class UserService {}',

--- a/aesc/tests/jsdoc/indexer.test.ts
+++ b/aesc/tests/jsdoc/indexer.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'bun:test'
-
-describe('JSDocIndexer', () => {
-    it('should be true', () => {
-        expect(true).toBe(true);
-    });
-});

--- a/aesc/tests/providers/ollama-provider.test.ts
+++ b/aesc/tests/providers/ollama-provider.test.ts
@@ -70,6 +70,8 @@ describe('OllamaProvider', () => {
     });
 
     it('should return an empty array on fetch failure', async () => {
+      const consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+      spies.push(consoleWarnSpy);
       fetchSpy.mockResolvedValue(new Response('Error', { status: 500 }));
       const models = await provider.getAvailableModels();
       expect(models).toEqual([]);


### PR DESCRIPTION
This commit addresses several issues with the test suite:

- The test in `aesc/tests/jsdoc/indexer.test.ts` was a placeholder and has been removed.
- The test case for graceful error handling in `aesc/tests/core/generator.test.ts` was logging an error message during successful test runs. This has been silenced by mocking `console.error`.
- The test case for fetch failures in `aesc/tests/providers/ollama-provider.test.ts` was logging a warning message during successful test runs. This has been silenced by mocking `console.warn`.

These changes result in a cleaner test output and remove a redundant test, improving the overall quality of the test suite.