### PR TITLE
fix(tests): Clean up test suite and fix mock leak

### DIFF
--- a/aesc/tests/core/generator.test.ts
+++ b/aesc/tests/core/generator.test.ts
@@ -6,6 +6,7 @@ import {
   spyOn,
   afterEach,
   beforeEach,
+  afterAll,
 } from 'bun:test'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -271,5 +272,18 @@ describe('generator', () => {
       expect(existsSyncSpy).toHaveBeenCalledWith('/output')
       expect(readdirSyncSpy).toHaveBeenCalledWith('/output')
     })
+  })
+
+  afterAll(() => {
+    // Restore original modules after all tests in this file have run
+    mock.module('../../src/file-analysis', () => import('../../src/file-analysis'))
+    mock.module('../../src/prompt-generator', () => import('../../src/prompt-generator'))
+    mock.module('../../src/model-caller', () => import('../../src/model-caller'))
+    mock.module('../../src/generation/code-cleaner', () => import('../../src/generation/code-cleaner'))
+    mock.module('../../src/generation/post-processor', () => import('../../src/generation/post-processor'))
+    mock.module('../../src/file-saver', () => import('../../src/file-saver'))
+    mock.module('../../src/generation/code-fixer', () => import('../../src/generation/code-fixer'))
+    mock.module('../../src/config', () => import('../../src/config'))
+    mock.module('../../src/jsdoc/indexer', () => import('../../src/jsdoc/indexer'))
   })
 })


### PR DESCRIPTION
This commit addresses several issues in the test suite to improve stability and cleanliness.

The key changes are:

1.  **Fix Module Mock Leak:** An `afterAll` hook has been added to `tests/core/generator.test.ts` to restore modules that were being mocked with `mock.module`. This was causing mocks to leak into other test files, leading to widespread and difficult-to-diagnose test failures depending on execution order.

2.  **Silence Noisy Tests:** Tests that are designed to test error handling were logging expected errors and warnings to the console during test runs. These have been silenced by spying on `console.error` and `console.warn` in the relevant tests (`generator.test.ts` and `ollama-provider.test.ts`).

3.  **Remove Invalid Test:** The test file `tests/jsdoc/indexer.test.ts` contained only a placeholder test (`expect(true).toBe(true)`) and has been removed.

These changes ensure that the test suite is reliable, the test output is clean, and all invalid or placeholder tests are removed.