### PR TITLE
feat: Add comprehensive e2e test suite

### DIFF
--- a/aesc_tests/gen_force/package.json
+++ b/aesc_tests/gen_force/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gen_simple_test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run src/index.ts"
+  }
+}

--- a/aesc_tests/gen_force/src/db-service.ts
+++ b/aesc_tests/gen_force/src/db-service.ts
@@ -1,0 +1,8 @@
+import { User } from './user';
+
+export abstract class DB {
+    // save user to db
+    abstract save(user: User): void;
+    // find user by name
+    abstract find(name: string): User | undefined;
+}

--- a/aesc_tests/gen_force/src/index.ts
+++ b/aesc_tests/gen_force/src/index.ts
@@ -1,0 +1,19 @@
+import { UserController } from './user-controller';
+import { User } from './user';
+import { container } from './generated/container';
+
+console.log('--- Simple Gen Test Start ---');
+
+const userController = new UserController();
+userController.userService = container.get('UserService');
+
+const newUser = new User('TestUser', 25);
+userController.create(newUser);
+
+const foundUser = userController.find('TestUser');
+
+console.assert(foundUser, 'Test Failed: User not found');
+console.assert(foundUser?.name === 'TestUser', 'Test Failed: User name does not match');
+console.assert(foundUser?.age === 25, 'Test Failed: User age does not match');
+
+console.log('--- Simple Gen Test End: All assertions passed ---');

--- a/aesc_tests/gen_force/src/user-controller.ts
+++ b/aesc_tests/gen_force/src/user-controller.ts
@@ -1,0 +1,16 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { UserService } from './user-service';
+
+export class UserController {
+    @AutoGen
+    public userService?: UserService;
+
+    create(user: User): void {
+        this.userService!.create(user);
+    }
+
+    find(name: string): User | undefined {
+        return this.userService!.findByName(name);
+    }
+}

--- a/aesc_tests/gen_force/src/user-service.ts
+++ b/aesc_tests/gen_force/src/user-service.ts
@@ -1,0 +1,14 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { DB } from './db-service';
+
+export abstract class UserService {
+    @AutoGen
+    public db?: DB;
+
+    // create a new user
+    abstract create(user: User): void;
+
+    // find a user by name
+    abstract findByName(name: string): User | undefined;
+}

--- a/aesc_tests/gen_force/src/user.ts
+++ b/aesc_tests/gen_force/src/user.ts
@@ -1,0 +1,3 @@
+export class User {
+    constructor(public name: string, public age: number) {}
+}

--- a/aesc_tests/gen_force/test.sh
+++ b/aesc_tests/gen_force/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running Force Gen Test ---"
+
+echo "-> Generating code for the first time..."
+aesc gen -v
+
+echo "-> Generating code again with --force..."
+aesc gen -v --force
+
+echo "-> Running application..."
+bun run start
+
+echo "--- Force Gen Test Passed ---"

--- a/aesc_tests/gen_force/tsconfig.json
+++ b/aesc_tests/gen_force/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "moduleResolution": "node"
+  }
+}

--- a/aesc_tests/gen_simple/package.json
+++ b/aesc_tests/gen_simple/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gen_simple_test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run src/index.ts"
+  }
+}

--- a/aesc_tests/gen_simple/src/db-service.ts
+++ b/aesc_tests/gen_simple/src/db-service.ts
@@ -1,0 +1,8 @@
+import { User } from './user';
+
+export abstract class DB {
+    // save user to db
+    abstract save(user: User): void;
+    // find user by name
+    abstract find(name: string): User | undefined;
+}

--- a/aesc_tests/gen_simple/src/index.ts
+++ b/aesc_tests/gen_simple/src/index.ts
@@ -1,0 +1,19 @@
+import { UserController } from './user-controller';
+import { User } from './user';
+import { container } from './generated/container';
+
+console.log('--- Simple Gen Test Start ---');
+
+const userController = new UserController();
+userController.userService = container.get('UserService');
+
+const newUser = new User('TestUser', 25);
+userController.create(newUser);
+
+const foundUser = userController.find('TestUser');
+
+console.assert(foundUser, 'Test Failed: User not found');
+console.assert(foundUser?.name === 'TestUser', 'Test Failed: User name does not match');
+console.assert(foundUser?.age === 25, 'Test Failed: User age does not match');
+
+console.log('--- Simple Gen Test End: All assertions passed ---');

--- a/aesc_tests/gen_simple/src/user-controller.ts
+++ b/aesc_tests/gen_simple/src/user-controller.ts
@@ -1,0 +1,16 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { UserService } from './user-service';
+
+export class UserController {
+    @AutoGen
+    public userService?: UserService;
+
+    create(user: User): void {
+        this.userService!.create(user);
+    }
+
+    find(name: string): User | undefined {
+        return this.userService!.findByName(name);
+    }
+}

--- a/aesc_tests/gen_simple/src/user-service.ts
+++ b/aesc_tests/gen_simple/src/user-service.ts
@@ -1,0 +1,14 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { DB } from './db-service';
+
+export abstract class UserService {
+    @AutoGen
+    public db?: DB;
+
+    // create a new user
+    abstract create(user: User): void;
+
+    // find a user by name
+    abstract findByName(name: string): User | undefined;
+}

--- a/aesc_tests/gen_simple/src/user.ts
+++ b/aesc_tests/gen_simple/src/user.ts
@@ -1,0 +1,3 @@
+export class User {
+    constructor(public name: string, public age: number) {}
+}

--- a/aesc_tests/gen_simple/test.sh
+++ b/aesc_tests/gen_simple/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running Simple Gen Test ---"
+
+echo "-> Generating code..."
+bun $AESC_PATH gen -v
+
+echo "-> Running application..."
+bun run start
+
+echo "--- Simple Gen Test Passed ---"

--- a/aesc_tests/gen_simple/tsconfig.json
+++ b/aesc_tests/gen_simple/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "moduleResolution": "node"
+  }
+}

--- a/aesc_tests/gen_specific_file/package.json
+++ b/aesc_tests/gen_specific_file/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gen_simple_test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run src/index.ts"
+  }
+}

--- a/aesc_tests/gen_specific_file/src/db-service.ts
+++ b/aesc_tests/gen_specific_file/src/db-service.ts
@@ -1,0 +1,8 @@
+import { User } from './user';
+
+export abstract class DB {
+    // save user to db
+    abstract save(user: User): void;
+    // find user by name
+    abstract find(name: string): User | undefined;
+}

--- a/aesc_tests/gen_specific_file/src/index.ts
+++ b/aesc_tests/gen_specific_file/src/index.ts
@@ -1,0 +1,19 @@
+import { UserController } from './user-controller';
+import { User } from './user';
+import { container } from './generated/container';
+
+console.log('--- Simple Gen Test Start ---');
+
+const userController = new UserController();
+userController.userService = container.get('UserService');
+
+const newUser = new User('TestUser', 25);
+userController.create(newUser);
+
+const foundUser = userController.find('TestUser');
+
+console.assert(foundUser, 'Test Failed: User not found');
+console.assert(foundUser?.name === 'TestUser', 'Test Failed: User name does not match');
+console.assert(foundUser?.age === 25, 'Test Failed: User age does not match');
+
+console.log('--- Simple Gen Test End: All assertions passed ---');

--- a/aesc_tests/gen_specific_file/src/order-service.ts
+++ b/aesc_tests/gen_specific_file/src/order-service.ts
@@ -1,0 +1,10 @@
+import { AutoGen } from 'aesc';
+import { DB } from './db-service';
+
+export abstract class OrderService {
+    @AutoGen
+    public db?: DB;
+
+    // create a new order
+    abstract createOrder(orderId: string): void;
+}

--- a/aesc_tests/gen_specific_file/src/user-controller.ts
+++ b/aesc_tests/gen_specific_file/src/user-controller.ts
@@ -1,0 +1,16 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { UserService } from './user-service';
+
+export class UserController {
+    @AutoGen
+    public userService?: UserService;
+
+    create(user: User): void {
+        this.userService!.create(user);
+    }
+
+    find(name: string): User | undefined {
+        return this.userService!.findByName(name);
+    }
+}

--- a/aesc_tests/gen_specific_file/src/user-service.ts
+++ b/aesc_tests/gen_specific_file/src/user-service.ts
@@ -1,0 +1,14 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { DB } from './db-service';
+
+export abstract class UserService {
+    @AutoGen
+    public db?: DB;
+
+    // create a new user
+    abstract create(user: User): void;
+
+    // find a user by name
+    abstract findByName(name: string): User | undefined;
+}

--- a/aesc_tests/gen_specific_file/src/user.ts
+++ b/aesc_tests/gen_specific_file/src/user.ts
@@ -1,0 +1,3 @@
+export class User {
+    constructor(public name: string, public age: number) {}
+}

--- a/aesc_tests/gen_specific_file/test.sh
+++ b/aesc_tests/gen_specific_file/test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running Specific File Gen Test ---"
+
+echo "-> Generating code for user-controller.ts only..."
+bun $AESC_PATH gen src/user-controller.ts -v
+
+echo "-> Checking generated files..."
+if [ ! -f "src/generated/userservice.service.impl.ts" ]; then
+    echo "FAIL: UserServiceImpl was not generated!"
+    exit 1
+fi
+if [ ! -f "src/generated/db.service.impl.ts" ]; then
+    echo "FAIL: DBImpl was not generated!"
+    exit 1
+fi
+if [ -f "src/generated/orderservice.service.impl.ts" ]; then
+    echo "FAIL: OrderServiceImpl was generated, but should not have been!"
+    exit 1
+fi
+echo "-> File check passed."
+
+echo "-> Running application..."
+bun run start
+
+echo "--- Specific File Gen Test Passed ---"

--- a/aesc_tests/gen_specific_file/tsconfig.json
+++ b/aesc_tests/gen_specific_file/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "moduleResolution": "node"
+  }
+}

--- a/aesc_tests/jsdoc_index/package.json
+++ b/aesc_tests/jsdoc_index/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "jsdoc_index_test",
+  "version": "1.0.0",
+  "dependencies": {
+    "ts-morph": "^26.0.0"
+  }
+}

--- a/aesc_tests/jsdoc_index/test.sh
+++ b/aesc_tests/jsdoc_index/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running JSDoc Index Test ---"
+
+CACHE_DIR=".aether-cache"
+
+echo "-> Installing dependencies..."
+bun install
+
+echo "-> Running 'index-jsdoc'..."
+bun $AESC_PATH index-jsdoc
+
+echo "-> Checking for cache directory..."
+if [ ! -d "$CACHE_DIR" ]; then
+    echo "FAIL: Cache directory '$CACHE_DIR' was not created!"
+    exit 1
+fi
+echo "-> Cache directory found."
+
+echo "-> Running 'clear-jsdoc'..."
+bun $AESC_PATH clear-jsdoc
+
+echo "-> Checking for cache directory removal..."
+if [ -d "$CACHE_DIR" ]; then
+    echo "FAIL: Cache directory '$CACHE_DIR' was not removed!"
+    exit 1
+fi
+echo "-> Cache directory removed."
+
+echo "--- JSDoc Index Test Passed ---"

--- a/aesc_tests/lock_unlock/package.json
+++ b/aesc_tests/lock_unlock/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gen_simple_test",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run src/index.ts"
+  }
+}

--- a/aesc_tests/lock_unlock/src/db-service.ts
+++ b/aesc_tests/lock_unlock/src/db-service.ts
@@ -1,0 +1,8 @@
+import { User } from './user';
+
+export abstract class DB {
+    // save user to db
+    abstract save(user: User): void;
+    // find user by name
+    abstract find(name: string): User | undefined;
+}

--- a/aesc_tests/lock_unlock/src/index.ts
+++ b/aesc_tests/lock_unlock/src/index.ts
@@ -1,0 +1,19 @@
+import { UserController } from './user-controller';
+import { User } from './user';
+import { container } from './generated/container';
+
+console.log('--- Simple Gen Test Start ---');
+
+const userController = new UserController();
+userController.userService = container.get('UserService');
+
+const newUser = new User('TestUser', 25);
+userController.create(newUser);
+
+const foundUser = userController.find('TestUser');
+
+console.assert(foundUser, 'Test Failed: User not found');
+console.assert(foundUser?.name === 'TestUser', 'Test Failed: User name does not match');
+console.assert(foundUser?.age === 25, 'Test Failed: User age does not match');
+
+console.log('--- Simple Gen Test End: All assertions passed ---');

--- a/aesc_tests/lock_unlock/src/user-controller.ts
+++ b/aesc_tests/lock_unlock/src/user-controller.ts
@@ -1,0 +1,16 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { UserService } from './user-service';
+
+export class UserController {
+    @AutoGen
+    public userService?: UserService;
+
+    create(user: User): void {
+        this.userService!.create(user);
+    }
+
+    find(name: string): User | undefined {
+        return this.userService!.findByName(name);
+    }
+}

--- a/aesc_tests/lock_unlock/src/user-service.ts
+++ b/aesc_tests/lock_unlock/src/user-service.ts
@@ -1,0 +1,14 @@
+import { AutoGen } from 'aesc';
+import { User } from './user';
+import { DB } from './db-service';
+
+export abstract class UserService {
+    @AutoGen
+    public db?: DB;
+
+    // create a new user
+    abstract create(user: User): void;
+
+    // find a user by name
+    abstract findByName(name: string): User | undefined;
+}

--- a/aesc_tests/lock_unlock/src/user.ts
+++ b/aesc_tests/lock_unlock/src/user.ts
@@ -1,0 +1,3 @@
+export class User {
+    constructor(public name: string, public age: number) {}
+}

--- a/aesc_tests/lock_unlock/test.sh
+++ b/aesc_tests/lock_unlock/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running Lock/Unlock Test ---"
+
+LOCKED_FILE="src/generated/userservice.service.impl.ts"
+
+echo "-> Generating code for the first time..."
+bun $AESC_PATH gen -v
+
+# Get the initial modification time of the file
+MOD_TIME_1=$(stat -c %Y "$LOCKED_FILE")
+
+echo "-> Locking the file: $LOCKED_FILE"
+bun $AESC_PATH lock $LOCKED_FILE
+
+# Wait a second to ensure the modification time will be different if the file is changed
+sleep 1
+
+echo "-> Trying to generate again with --force (should be blocked by lock)..."
+bun $AESC_PATH gen -v --force
+
+# Get the modification time again
+MOD_TIME_2=$(stat -c %Y "$LOCKED_FILE")
+
+if [ "$MOD_TIME_1" -ne "$MOD_TIME_2" ]; then
+    echo "FAIL: Locked file was modified!"
+    exit 1
+fi
+echo "-> Locked file was not modified, as expected."
+
+echo "-> Unlocking the file: $LOCKED_FILE"
+bun $AESC_PATH unlock $LOCKED_FILE
+
+# Wait a second again
+sleep 1
+
+echo "-> Generating again with --force (should now succeed)..."
+bun $AESC_PATH gen -v --force
+
+# Get the modification time for the final time
+MOD_TIME_3=$(stat -c %Y "$LOCKED_FILE")
+
+if [ "$MOD_TIME_2" -eq "$MOD_TIME_3" ]; then
+    echo "FAIL: Unlocked file was not modified!"
+    exit 1
+fi
+echo "-> Unlocked file was modified, as expected."
+
+echo "--- Lock/Unlock Test Passed ---"

--- a/aesc_tests/lock_unlock/tsconfig.json
+++ b/aesc_tests/lock_unlock/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "moduleResolution": "node"
+  }
+}

--- a/aesc_tests/provider_list/test.sh
+++ b/aesc_tests/provider_list/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running List Providers Test ---"
+
+echo "-> Running 'aesc list-providers'..."
+OUTPUT=$(aesc list-providers)
+
+echo "$OUTPUT"
+
+echo "-> Checking for 'ollama'..."
+echo "$OUTPUT" | grep -q "ollama"
+echo "-> Checking for 'cloudflare'..."
+echo "$OUTPUT" | grep -q "cloudflare"
+
+echo "--- List Providers Test Passed ---"

--- a/aesc_tests/provider_test/test.sh
+++ b/aesc_tests/provider_test/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Running Test Provider Test ---"
+
+echo "-> Running 'test-provider -p ollama'..."
+# This test assumes a local Ollama instance is running.
+OUTPUT=$(bun $AESC_PATH test-provider -p ollama)
+
+echo "$OUTPUT"
+
+echo "-> Checking for success message..."
+echo "$OUTPUT" | grep -q "Provider 'ollama' is configured correctly."
+
+echo "--- Test Provider Test Passed ---"

--- a/aesc_tests/run_tests.sh
+++ b/aesc_tests/run_tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+BASE_DIR=$(pwd)
+TEST_DIR="$BASE_DIR/aesc_tests"
+
+echo "Base directory: $BASE_DIR"
+echo "Test directory: $TEST_DIR"
+
+# Define the path to the aesc executable
+export AESC_PATH="$BASE_DIR/aesc/dist/index.js"
+
+if [ ! -f "$AESC_PATH" ]; then
+    echo "Aesc executable not found at $AESC_PATH"
+    echo "Building aesc..."
+    (cd "$BASE_DIR/aesc" && bun install && bun run build)
+fi
+
+echo "Aesc executable found at: $AESC_PATH"
+
+run_test() {
+    TEST_NAME=$1
+    echo "--- Running test: $TEST_NAME ---"
+    if (cd "$TEST_DIR/$TEST_NAME" && ./test.sh); then
+        echo "--- Test $TEST_NAME PASSED ---"
+    else
+        echo "--- Test $TEST_NAME FAILED ---"
+        exit 1
+    fi
+}
+
+# --- Run all tests ---
+run_test "gen_simple"
+run_test "gen_force"
+run_test "gen_specific_file"
+run_test "provider_list"
+run_test "provider_test"
+run_test "lock_unlock"
+run_test "jsdoc_index"
+
+echo "All tests passed!"


### PR DESCRIPTION
This commit introduces a new end-to-end test suite for the `aesc` command-line tool. The tests are designed to run without modifying the `src` directory and without using mocks, relying on a live (local) AI provider.

The test suite is located in the `aesc_tests` directory and includes tests for:
- Core code generation (`gen` command)
- The `--force` and `--files` options for `gen`
- Provider commands (`list-providers`, `test-provider`)
- File locking commands (`lock`, `unlock`)
- JSDoc indexing commands (`index-jsdoc`, `clear-jsdoc`)

A master `run_tests.sh` script is provided to execute all test cases sequentially.